### PR TITLE
Update Merchant.php

### DIFF
--- a/Merchant.php
+++ b/Merchant.php
@@ -24,10 +24,6 @@ class Merchant extends BaseObject
 
         $signature = "{$this->sMerchantLogin}:{$nOutSum}:{$nInvId}:{$this->sMerchantPass1}";
 
-        if (!empty($shp)) {
-            $signature .= ':' . $this->implodeShp($shp);
-        }
-
         $sSignatureValue = $this->encryptSignature($signature);
 
         $url .= '?' . http_build_query([


### PR DESCRIPTION
Дополнительные данные которые передаются в момент формирования платежа не должны участвовать в подписи. Столкнулся с этим когда начал передавать параметр по умолчанию для оплаты только картой и все сломалось.